### PR TITLE
Massive N^2 speedup by implementing translational symmetries in Fourier Space

### DIFF
--- a/Modules/tdscha_core.jl
+++ b/Modules/tdscha_core.jl
@@ -121,7 +121,7 @@ function get_d2v_dR2_from_Y_pert_sym_fast(ensemble::Ensemble{T}, symmetries::Vec
     buffer_u = zeros(T, n_modes) 
 
 
-    Threads.@threads for bigindex = start_index:end_index
+    for bigindex = start_index:end_index
         i = Int32(floor((bigindex - 1) / n_symmetries)) + 1
         j = mod((bigindex - 1), n_symmetries) + 1
     


### PR DESCRIPTION
This branch should implement the calculation of the perturbation directly in Fourier Space.
This is obtained by exploiting the relation

$$
\left<\frac{d^2V}{dR^2}\right>(q) =\left<\Upsilon u(q) \delta f(-q)\right>
$$

This means that this relation can be written as block diagonal, obtaining a N-scaling speedup in case of large supercell.
Not only, this automatically impose the translational symmetry, getting an additional N scaling advantage over the fully replica symmetries algorithm currently implemented as the fast_lanczos algorithm. This implementation should therefore produce a N^2 scaling, bringing the application of Lanczos + v4 on the same computational cost as the standard SSCHA.