### PR TITLE
Fix save_abc dropping the last a coefficient

### DIFF
--- a/Modules/DynamicalLanczos.py
+++ b/Modules/DynamicalLanczos.py
@@ -3658,12 +3658,12 @@ Error, for the static calculation the vector must be of dimension {}, got {}
         In this way the calculation cannot be restarted.
         """
 
-        total_len = len(self.c_coeffs)
+        total_len = len(self.a_coeffs)
 
         abc = np.zeros( (total_len, 3), dtype = np.double)
-        abc[:,0] = self.a_coeffs[:total_len]
-        abc[:,1] = self.b_coeffs
-        abc[:,2] = self.c_coeffs
+        abc[:,0] = self.a_coeffs
+        abc[:len(self.b_coeffs),1] = self.b_coeffs
+        abc[:len(self.c_coeffs),2] = self.c_coeffs
 
         np.savetxt(file, abc, header = "a; b; c")
 


### PR DESCRIPTION
## Summary

- `save_abc()` used `len(c_coeffs)` as the array dimension, but in the biconjugate Lanczos (`run_FT`) `len(a_coeffs) = N` while `len(b_coeffs) = len(c_coeffs) = N-1`, so the last diagonal coefficient `a[N-1]` was silently dropped.
- Now uses `len(a_coeffs)` as the leading dimension and fills `b`/`c` only for the available rows. The last row has `b = c = 0`, consistent with the termination of the continued fraction.

## Test plan

- [x] Verified on LaAlO3 T=200K IR calculation (nconf=10000, 3 polarizations, 2nd order) that `save_abc` now writes all coefficients and the resulting spectrum is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)